### PR TITLE
Meal plan interactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'sorcery'
 gem 'pg', '~> 1.2.3'
 gem 'delayed_job_active_record', '~> 4.1.6'
 gem "interactor", "~> 3.0"
+gem "pundit", "~> 2.2"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -30,10 +30,11 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'sorcery'
 gem 'pg', '~> 1.2.3'
 gem 'delayed_job_active_record', '~> 4.1.6'
+gem "interactor", "~> 3.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
   gem 'factory_bot_rails'
   gem 'dotenv-rails'
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,6 @@ GEM
     bullet (7.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     capybara (3.34.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -80,6 +79,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     delayed_job (4.1.9)
@@ -105,6 +105,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    interactor (3.1.2)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     jwt (2.2.1)
@@ -137,6 +138,11 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     pg (1.2.3)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (5.5.1)
       nio4r (~> 2.0)
@@ -257,14 +263,15 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   bullet
-  byebug
   capybara (>= 2.15)
   delayed_job_active_record (~> 4.1.6)
   dotenv-rails
   factory_bot_rails
+  interactor (~> 3.0)
   jbuilder (~> 2.10)
   listen (>= 3.0.5, < 3.7)
   pg (~> 1.2.3)
+  pry-rails
   puma (~> 5.5)
   rails (~> 6.1.3)
   rspec-rails (~> 4.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.1)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
@@ -273,6 +275,7 @@ DEPENDENCIES
   pg (~> 1.2.3)
   pry-rails
   puma (~> 5.5)
+  pundit (~> 2.2)
   rails (~> 6.1.3)
   rspec-rails (~> 4.0.2)
   sass-rails (>= 6)

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -13,15 +13,18 @@ class MealPlansController < ApplicationController
   end
 
   def create
-    @meal_plan = MealPlan.new(meal_plan_params)
-    @meal_plan.user = current_user
-    needed_recipes = @meal_plan.number_of_meals
-    recipes = Recipe.ordered_random.limit(needed_recipes)
-    @meal_plan.recipes << recipes
+    # TODO: Move guard claused to pundit
+    needed_recipes = meal_plan_params[:number_of_meals]
+    redirect_to recipes_path and return if current_user.recipes.none?
+    redirect_to recipes_path and return if needed_recipes.to_i > current_user.recipes.count
 
-    if @meal_plan.save
+    result = CommitMealPlan.call(params: meal_plan_params, proposal: params[:proposal].present?, user: current_user)
+    if result.success?
+      @meal_plan = result.meal_plan
+      @shopping_list = result.shopping_list
       redirect_to meal_plan_path(@meal_plan)
     else
+      flash[:notice] = "Something went wrong"
       render :new
     end
   end
@@ -79,6 +82,6 @@ class MealPlansController < ApplicationController
   end
 
   def meal_plan_params
-    params.require(:meal_plan).permit(:number_of_meals)
+    params.require(:meal_plan).permit(:number_of_meals, :proposal)
   end
 end

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -82,6 +82,6 @@ class MealPlansController < ApplicationController
   end
 
   def meal_plan_params
-    params.require(:meal_plan).permit(:number_of_meals, :proposal)
+    params.require(:meal_plan).permit(:number_of_meals)
   end
 end

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -1,6 +1,11 @@
 class MealPlansController < ApplicationController
   def new
-    @meal_plan = MealPlan.new(number_of_meals: 2)
+    if current_user.meal_plans.uncommitted.any?
+      flash[:notice] = "You have an uncommitted meal plan lying around"
+      redirect_to meal_plan_path(current_user.meal_plans.uncommitted.first)
+    else
+      @meal_plan = MealPlan.new(number_of_meals: 2)
+    end
   end
 
   def index
@@ -37,7 +42,7 @@ class MealPlansController < ApplicationController
   def swap_recipe
     @meal_plan = MealPlan.find(params[:id])
     raise ActionController::RoutingError.new('Not Found') unless meal_plan_accessible?
-    return unless @meal_plan.recipes_changable
+    return unless @meal_plan.recipes_changable?
 
     recipe_ids = @meal_plan.recipe_ids
 

--- a/app/interactors/commit_meal_plan.rb
+++ b/app/interactors/commit_meal_plan.rb
@@ -1,0 +1,38 @@
+class CommitMealPlan
+  include Interactor
+
+  delegate :params, :proposal, :user,  to: :context
+
+  def call
+    @meal_plan = MealPlan.new(params)
+    @meal_plan.user = user
+    needed_recipes = params[:number_of_meals].to_i
+    @meal_plan.recipes << get_recipes
+
+    if !proposal
+      commit_meal_plan
+    end
+
+    if needed_recipes == user.recipes.count
+     commit_meal_plan
+    end
+
+    if @meal_plan.save
+      context.meal_plan = @meal_plan
+      context.shopping_list = @shopping_list
+    else 
+      context.fail!
+    end
+  end
+
+  private
+
+  def commit_meal_plan
+    @meal_plan.committed = true
+    @shopping_list = ShoppingList.build_from_meal_plan(@meal_plan, user)
+  end
+
+  def get_recipes 
+    user.recipes.ordered_random.limit(@meal_plan.number_of_meals)
+  end
+end

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -5,8 +5,9 @@ class MealPlan < ApplicationRecord
 
   scope :most_recent, -> { order('created_at DESC').first }
   scope :committed, -> { where(committed: true) }
+  scope :uncommitted, -> { where(committed: false) }
 
-  def recipes_changable
+  def recipes_changable?
     enough_recipes? && !shopping_list.present?
   end
 

--- a/app/views/meal_plans/_form.html.erb
+++ b/app/views/meal_plans/_form.html.erb
@@ -1,4 +1,8 @@
 <%= form_with(model: meal_plan, local: true) do |form| %>
+  <% if local_assigns[:proposal] %>
+    <%= hidden_field_tag(:proposal, value: true) %>
+  <% end %>
+  
   <% if meal_plan.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(meal_plan.errors.count, "error") %> prohibited this meal plan from being saved:</h2>

--- a/app/views/meal_plans/new.html.erb
+++ b/app/views/meal_plans/new.html.erb
@@ -1,4 +1,4 @@
 <div class="max-w-xl rounded overflow-hidden shadow-lg rounded-md bg-white sm:mt-8 md:mt-16 mx-auto p-4 mb-16">
   <h1 class="text-xl font-extrabold mb-4">New Meal Plan</h1>
-  <%= render 'form', meal_plan: @meal_plan %>
+  <%= render 'form', meal_plan: @meal_plan, proposal: true %>
 </div>

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -9,14 +9,14 @@
       <% if recipe.description.present? %>
         <p class="mb-4"><%= recipe.description %></p>
       <% end %>
-      <% if @meal_plan.recipes_changable %>
+      <% if @meal_plan.recipes_changable? %>
         <%= link_to 'Swap out recipe', meal_plan_swap_recipe_path(@meal_plan.id, recipe_id: recipe.id), method: :post, class: 'SecondaryButton' %>
       <% end %>
     </div>
   <% end %>
 </div>
 
-<% if !@meal_plan.recipes_changable && !@meal_plan.enough_recipes? && !@meal_plan.committed? %>
+<% if !@meal_plan.recipes_changable? && !@meal_plan.enough_recipes? && !@meal_plan.committed? %>
   <div class="text-center">
     <p>Recipes are not changable since you do not have enought recipes in your database</p>
     <%= link_to 'Add more', new_recipe_path, class: 'TextButton mt-2 inline-block' %>
@@ -27,7 +27,7 @@
   <%= link_to 'Commit', meal_plan_with_shopping_list_path(@meal_plan.id), method: :post, class: 'SecondaryButton' %>
 <% end %>
 
-<% if @meal_plan.shopping_list %>
+<% if @meal_plan.committed? %>
   <div class="mt-8" data-controller="shopping-list-item">
     <h2 class="SecondaryHeadline ">Shopping List</h2>
     <table class="table-auto">

--- a/spec/factories/meal_plan_factory.rb
+++ b/spec/factories/meal_plan_factory.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
 
       meal_plan.reload
     end
+
+    trait :committed do
+      committed { true }
+    end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     invite_code { FactoryBot.create(:invite_code).code }
 
     trait :needs_activation do
-      activation_token { 'asd' } 
+      activation_token { 'asd' }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,18 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Sorcery::TestHelpers::Internal
+  config.include Sorcery::TestHelpers::Internal::Rails
+  config.include Sorcery::TestHelpers::Rails::Controller
+  config.include Sorcery::TestHelpers::Rails::Integration
+  config.include Sorcery::TestHelpers::Rails::Request
+
+  config.before(:each) do
+    Bullet.enable = false
+  end
+
+  config.after(:each) do
+    Bullet.enable = true
+  end
 end

--- a/spec/request/meal_plan_spec.rb
+++ b/spec/request/meal_plan_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "MealPlan requests", type: :request do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before(:each) do
+    user.activate!
+    login_user(user, 'Test1234')
+  end
+
+  describe "#index" do
+    subject { get new_meal_plan_path }
+
+    it "renders new if no uncommited meal plans pending" do
+      expect(subject).not_to have_http_status(:redirect)
+    end
+
+    it "redirects to show if uncommitted meal plan present" do
+      meal_plan = FactoryBot.create(:meal_plan, user: user)
+      expect(subject).to redirect_to(meal_plan_path(meal_plan))
+    end
+  end
+
+  describe "#create" do
+    let!(:meal_plan) { FactoryBot.build(:meal_plan) }
+    subject { post meal_plans_path(meal_plan: meal_plan.attributes) }
+
+    it "redirects to recipes_path if user has no recipes" do
+      expect(subject).to redirect_to(recipes_path)
+    end
+
+    context ":proposal param set" do
+      subject { post meal_plans_path(meal_plan: meal_plan.attributes, proposal: true) }
+      before do
+        FactoryBot.create_list(:recipe, 10, user: user)
+      end
+
+      it "does create an uncommited MealPlan" do
+        expect { subject }.to change { MealPlan.count }.by(1)
+        expect(MealPlan.last.committed).to be false
+      end
+
+      it "does not create a shopping list" do
+        subject
+        expect(MealPlan.last.shopping_list).to be_nil
+      end
+
+      it "creates a commited meal plan if number of meals equals users recipes" do
+        meal_plan.number_of_meals = user.recipes.count
+        
+        expect{ subject }.to change { MealPlan.count }.by(1)
+        expect(MealPlan.last.committed).to be true
+        expect(MealPlan.last.shopping_list.present?).to be true
+      end
+
+      it "redirects to #show" do
+        expect(subject).to redirect_to meal_plan_path(MealPlan.last.id)
+      end
+    end
+
+    context ":proposal param not set" do
+      subject { post meal_plans_path(meal_plan: meal_plan.attributes) }
+      before do
+        FactoryBot.create_list(:recipe, 10, user: user)
+      end
+
+      it "does create an commited MealPlan" do
+        expect { subject }.to change { MealPlan.count }.by(1)
+        expect(MealPlan.last.committed).to be true
+      end
+
+      it "creates a shopping list" do
+        subject
+        expect(MealPlan.last.shopping_list.present?).to be true
+      end
+
+      it "redirects to show" do
+        expect(subject).to redirect_to meal_plan_path(MealPlan.last.id)
+      end
+    end
+
+  end
+end

--- a/spec/request/meal_plan_spec.rb
+++ b/spec/request/meal_plan_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "MealPlan requests", type: :request do
         expect(MealPlan.last.shopping_list).to be_nil
       end
 
-      it "creates a commited meal plan if number of meals equals users recipes" do
+      it "creates a commited meal plan and overrides the proposal param if number of meals equals users recipes" do
         meal_plan.number_of_meals = user.recipes.count
         
         expect{ subject }.to change { MealPlan.count }.by(1)


### PR DESCRIPTION
Moves meal plan creation logic to an interactor to keep the controller slim.  
Also, some changes to how meal plan are created:

* If the user has not enough (or no recipes at all), the controller returns early
* By default, meal plans are still drafts and recipes can be swapped out
* If the user has exactly as many recipes as needed, meal plan is committed by default

Other changes:

* If the user still has an uncommitted meal plan, they are redirected there instead of creating a new one

Relates to #179 
Closes #156 